### PR TITLE
fix: incorrect environment variable name

### DIFF
--- a/scripts/rephrase-selection.sh
+++ b/scripts/rephrase-selection.sh
@@ -37,7 +37,7 @@ temp=$(echo "scale = 1; $temperature / 10" | bc)
 response=$(curl --silent --max-time 15 https://api.openai.com/v1/chat/completions \
 	-H "Content-Type: application/json" \
 	-H "Authorization: Bearer $apikey" \
-	-d "{ \"model\": \"$model\", \"messages\": [{\"role\": \"user\", \"content\": \"$the_prompt\"}], \"temperature\": $temp }")
+	-d "{ \"model\": \"$openai_model\", \"messages\": [{\"role\": \"user\", \"content\": \"$the_prompt\"}], \"temperature\": $temp }")
 
 # log the response to stderr (= visible in Alfred debug log, but not elsewhere)
 echo "OpenAI response:" >&2


### PR DESCRIPTION
hi @chrisgrieser,

This is a very useful tool!

I corrected an error introduced in the latest version where the environment variable name `model` was used instead of `openai_model`.

```diff

diff --git a/scripts/rephrase-selection.sh b/scripts/rephrase-selection.sh
index aaa25a0..9c02a40 100755
--- a/scripts/rephrase-selection.sh
+++ b/scripts/rephrase-selection.sh
@@ -37,7 +37,7 @@ temp=$(echo "scale = 1; $temperature / 10" | bc)
 response=$(curl --silent --max-time 15 https://api.openai.com/v1/chat/completions \
        -H "Content-Type: application/json" \
        -H "Authorization: Bearer $apikey" \
-       -d "{ \"model\": \"$model\", \"messages\": [{\"role\": \"user\", \"content\": \"$the_prompt\"}], \"temperature\": $temp }")
+       -d "{ \"model\": \"$openai_model\", \"messages\": [{\"role\": \"user\", \"content\": \"$the_prompt\"}], \"temperature\": $temp }")

 # log the response to stderr (= visible in Alfred debug log, but not elsewhere)
 echo "OpenAI response:" >&2
```

Happy weekend :)

